### PR TITLE
Moved KickStart and ISO generation into it's own thread.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
 History
 =====================
 
+1.0alpha8 (2021-09-24)
+---------------------
+* moved KickStart and ISO generation into it's own subprocess
+
 1.0alpha7 (2021-09-20)
 ---------------------
 * hide passwords in web form

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ In 'Step 1' is where you setup your basic installation settings.\
 In 'Step 2' you configure the IP settings for the ESXi hosts.
 
 Once all the correct settings have been entered, click the "START" button on the bottom to begin the installation process.\
-Once you click Start, you will be sent to the "Status Page". Please note this may take a while if several jobs are being run in parrallel - do not navigate off the main page until this process is finished and "Status Page" is presented.
+Once you click Start, you will be sent to the "Status Page".
 
 ## Status page
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,7 +12,7 @@
       <!--<div class="logo"><img src="{{ url_for('static', filename='cisco-logo.png') }}" alt="Cisco Logo"/></div>-->
       <div class="page_header">
         <div>ESXi Auto-Installer</div>
-        <div class="version">(v1.0 2021-09-20)</div>
+        <div class="version">(v1.0 2021-09-24)</div>
       </div>
       <div id="navbar" class="menu">
         <a href="{{ url_for('autoinstaller_gui') }}">Home</a>


### PR DESCRIPTION
Moved KickStart and ISO generation into it's own thread so START button responds quickly.
Purposefully left the Kickstart and ISO generation sequential so we don't kill this disk with simultaneous ISO generations