### PR TITLE
cimc_unmount_iso and job_cleanup optimisation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 History
 =====================
 
+1.0alpha10 (2021-10-11)
+---------------------
+* cimc_unmount_iso unmounts only the ISO related to specific job ID
+* job_cleanup - added unmount_iso boolean so that we can skip unmounting when we got CIMC authentiocation error
+* removed get_main_logger() call from function declarations
+
 1.0alpha9 (2021-10-01)
 ---------------------
 * rebuilt API with flask_restful

--- a/app/autoinstaller_api.py
+++ b/app/autoinstaller_api.py
@@ -34,7 +34,8 @@ class EAIJobs(Resource):
         # api endpoint for getting details for all jobs
         return eaidb_get_status(), 200
 
-    def post(self, mainlog=get_main_logger()):
+    def post(self):
+        mainlog=get_main_logger()
         try:
             jobid_list = []
             install_data = {}
@@ -48,7 +49,7 @@ class EAIJobs(Resource):
             mainlog.debug(f'API /jobs endpoint called with args: {args}')
 
             # interate over the list of ESXi hosts and run corresponding actions for each host
-            jobid_list = create_jobs(install_data)
+            jobid_list = create_jobs(install_data, mainlog)
             return jobid_list
         except KeyError as e:
             return f'Incorrect key when trying to create a new job. Expected key: {str(e)}', 400

--- a/app/autoinstaller_gui.py
+++ b/app/autoinstaller_gui.py
@@ -34,7 +34,7 @@ def autoinstaller_gui():
         mainlog = get_main_logger()
         mainlog.debug(result)
         # interate over the list of ESXi hosts and run corresponding actions for each host
-        create_jobs(get_form_data(mainlog, result))
+        create_jobs(get_form_data(mainlog, result), mainlog)
         return redirect(url_for('show'))
     return render_template('index.html', form=form, isodirs=dirs)
 
@@ -81,7 +81,8 @@ def logs(jobid):
 
 # upload and extract ISO
 @app.route('/upload', methods=['GET', 'POST'])
-def upload_iso(mainlog=get_main_logger()):
+def upload_iso():
+    mainlog=get_main_logger()
     if request.method == 'POST':
         # read file name
         uploaded_iso = request.files['file']

--- a/app/generic_functions.py
+++ b/app/generic_functions.py
@@ -46,9 +46,6 @@ def get_jobid_logger(jobid=generate_jobid(), logdir=LOGDIR):
 
     # Get/create a logger
     logger = logging.getLogger(jobid.replace('.','_'))
-    # TODO: remove debugging code
-    # print(f'[DEBUG] Configuring job logger: {logger}, PID: {os.getpid()}')
-
     if not logger.hasHandlers():
         # set log level
         logger.setLevel(logging.DEBUG)
@@ -72,8 +69,6 @@ def get_main_logger(log_file=EAILOG):
 
     # Get/create main application logger
     main_logger = logging.getLogger('main')
-    # TODO: remove debugging code
-    # print(f'[DEBUG] Configuring main logger: {main_logger}, PID: {os.getpid()}')
     # set log level
     main_logger.setLevel(logging.DEBUG)
     # define formatter

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,7 +12,7 @@
       <!--<div class="logo"><img src="{{ url_for('static', filename='cisco-logo.png') }}" alt="Cisco Logo"/></div>-->
       <div class="page_header">
         <div>ESXi Auto-Installer</div>
-        <div class="version">(v1.0 2021-10-01)</div>
+        <div class="version">(v1.0 2021-10-11)</div>
       </div>
       <div id="navbar" class="menu">
         <a href="{{ url_for('autoinstaller_gui') }}">Home</a>


### PR DESCRIPTION
* cimc_unmount_iso unmounts only the ISO related to specific job ID
* job_cleanup - added unmount_iso boolean so that we can skip unmounting when we got CIMC authentication error
* removed get_main_logger() call from function declarations