### PR TITLE
Use http instead of https when port 80 is provided in CIMC IP address

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
 History
 =====================
 
+1.2 (2021-12-03)
+---------------------
+* use http instead of https when port 80 is provided in CIMC IP address
+
 1.1 (2021-11-09)
 ---------------------
 * SHA512 hashed root password in kickstart file

--- a/app/autoinstaller_functions.py
+++ b/app/autoinstaller_functions.py
@@ -300,9 +300,13 @@ def cimc_login(logger, cimcaddr, cimcusr, cimcpwd, dryrun=DRYRUN):
         else:
             cimcip = cimcaddr
             cimcport = 443
-
+        if cimcport == 80:
+            # ImcSeccion in imcsdk does not seem to handle non-secure port 80 correctly - let's workaround it here
+            cimcsecure = False
+        else:
+            cimcsecure = True
         # Create a connection handle
-        cimchandle = ImcHandle(cimcip, cimcusr, cimcpwd, cimcport)
+        cimchandle = ImcHandle(cimcip, cimcusr, cimcpwd, cimcport, cimcsecure)
         # Login to CIMC
         cimchandle.login()
         logger.info(f'Connected to CIMC: {cimcaddr}')

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,7 +12,7 @@
       <!--<div class="logo"><img src="{{ url_for('static', filename='cisco-logo.png') }}" alt="Cisco Logo"/></div>-->
       <div class="page_header">
         <div>ESXi Auto-Installer</div>
-        <div class="version">(v1.1 2021-11-09)</div>
+        <div class="version">(v1.2 2021-12-03)</div>
       </div>
       <div id="navbar" class="menu">
         <a href="{{ url_for('autoinstaller_gui') }}">Home</a>


### PR DESCRIPTION
Quick fix implementing workaround for issue #26 (Error when trying to login to CIMC), as apparently ImcSession from IMC SDK does not switch to non-secure connection for port 80.